### PR TITLE
Gracefully handle project aliases that have uppercase letters

### DIFF
--- a/src/utils/file.ts
+++ b/src/utils/file.ts
@@ -40,7 +40,7 @@ export function readProjectInfoFromProjectFile(resolver: Resolver, path: string)
 
 export function readProjectIdFromProjectFile(resolver: Resolver, path: string): string | undefined {
   const contents = resolver.read(path)
-  const matches = contents.match(/# project: ([a-z0-9-]*)/)
+  const matches = contents.match(/# project: ([a-zA-Z0-9-]*)/)
 
   if (!matches || matches.length !== 2) {
     return undefined

--- a/tests/mock_data/mockData.ts
+++ b/tests/mock_data/mockData.ts
@@ -47,6 +47,13 @@ export const mockProjectFileWithAlias2 = `\
 ${simpleTwitterSchemaWithSystemFields}
 `
 
+export const mockProjectFileWithUppercaseAlias1 = `\
+# project: Example
+# version: 1
+
+${simpleTwitterSchemaWithSystemFields}
+`
+
 export const mockProjectFile3 = `\
 # project: abcdefghijklmn
 # version: 3

--- a/tests/utils_file.test.ts
+++ b/tests/utils_file.test.ts
@@ -1,0 +1,53 @@
+import test from 'ava'
+import TestResolver from '../src/system/TestResolver'
+import TestOut from '../src/system/TestOut'
+import { graphcoolProjectFileName } from '../src/utils/constants'
+import { TestSystemEnvironment } from '../src/types'
+import { mockProjectFile1, mockProjectFileWithUppercaseAlias1 } from './mock_data/mockData'
+import { readProjectIdFromProjectFile } from '../src/utils/file'
+
+/*
+ Tests:
+ - readProjectIdFromProjectFile with a file containing a project id
+ - readProjectIdFromProjectFile with a file containing a project alias
+ - readProjectIdFromProjectFile with a file missing a project id
+ */
+
+test.afterEach(() => {
+  new TestOut().write('\n')
+})
+
+test('readProjectIdFromProjectFile with a file containing a project id', async t => {
+  const env = testEnvironment({})
+  env.resolver.write(graphcoolProjectFileName, mockProjectFile1)
+
+  const project_id = readProjectIdFromProjectFile(env.resolver, graphcoolProjectFileName)
+
+  t.is(project_id, 'abcdefghijklmn')
+})
+
+test('readProjectIdFromProjectFile with a file containing a project alias', async t => {
+  const env = testEnvironment({})
+  env.resolver.write(graphcoolProjectFileName, mockProjectFileWithUppercaseAlias1)
+
+  const project_id = readProjectIdFromProjectFile(env.resolver, graphcoolProjectFileName)
+
+  t.is(project_id, 'Example')
+})
+
+test('readProjectIdFromProjectFile with a file missing a project id', async t => {
+  const env = testEnvironment({})
+  env.resolver.write(graphcoolProjectFileName, '')
+
+  const project_id = readProjectIdFromProjectFile(env.resolver, graphcoolProjectFileName)
+
+  t.is(project_id, undefined)
+})
+
+
+function testEnvironment(storage: any): TestSystemEnvironment {
+  return {
+    resolver: new TestResolver(storage),
+    out: new TestOut(),
+  }
+}


### PR DESCRIPTION
While playing with Graphcool I accidentally used an uppercase letter in a project alias.

The next time I tried to `graphcool push` I got the following error:

```
✖  Error: The project file (project.graphcool) that you provided doesn't seem to be valid.
Please make sure it contains the ID of your project.
```

After some debugging I discovered the regex used to match project id did not accept uppercase letters.

I resolved that issue and added a few tests for the `readProjectIdFromProjectFile` function.

Feel free to close this if you feel this overkill.

cc @schickling @nikolasburk 