### PR TITLE
Add config to SystemEnvironment

### DIFF
--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -1,4 +1,3 @@
-import { writeGraphcoolConfig, deleteGraphcoolConfig } from '../utils/file'
 import { AuthServer, SystemEnvironment } from '../types'
 import { sleep } from '../utils/system'
 import {
@@ -33,10 +32,12 @@ export default async (props: Props, env: SystemEnvironment, authServer: AuthServ
 
   const authenticatedUserEmail = await authServer.validateAuthToken(token)
   if (authenticatedUserEmail) {
-    writeGraphcoolConfig({token}, resolver)
+    env.config.set({ token })
+    env.config.save()
     out.write(authenticationSuccessMessage(authenticatedUserEmail))
   } else {
-    deleteGraphcoolConfig(resolver)
+    env.config.unset('token')
+    env.config.save()
     throw new Error('Invalid auth token')
   }
 

--- a/src/commands/console.ts
+++ b/src/commands/console.ts
@@ -1,4 +1,4 @@
-import {readGraphcoolConfig, readProjectIdFromProjectFile, isValidProjectFilePath} from '../utils/file'
+import {readProjectIdFromProjectFile, isValidProjectFilePath} from '../utils/file'
 import {SystemEnvironment, ProjectInfo} from '../types'
 import open = require('open')
 import { pullProjectInfo } from '../api/api'
@@ -16,7 +16,7 @@ interface Props {
 export default async (props: Props, env: SystemEnvironment): Promise<void> => {
   const {resolver, out} = env
 
-  const {token} = readGraphcoolConfig(resolver)
+  const token = env.config.get('token')
   if (!token) {
     throw new Error(notAuthenticatedMessage)
   }

--- a/src/commands/interactiveInit.ts
+++ b/src/commands/interactiveInit.ts
@@ -34,7 +34,7 @@ export default async (props: Props, env: SystemEnvironment): Promise<void> => {
   // no need for interactivity when there are no options
   // NOTE: this should probably be refactored to an outer layer
   if (schemaFiles.length === 0 && projectFiles.length === 0) {
-    await props.checkAuth('init')
+    await props.checkAuth(env, 'init')
 
     const schemaUrl = sampleSchemaURL
     const initProps = getPropsForInit(props)
@@ -101,7 +101,7 @@ async function handleSelect(selectedIndex: number, props: Props, env: SystemEnvi
   if (selectedIndex === BLANK_PROJECT) {
     terminal.grabInput(false)
 
-    await props.checkAuth('init')
+    await props.checkAuth(env, 'init')
   }
 
   switch (selectedIndex) {

--- a/src/commands/playground.ts
+++ b/src/commands/playground.ts
@@ -1,4 +1,4 @@
-import {readGraphcoolConfig, readProjectIdFromProjectFile, isValidProjectFilePath} from '../utils/file'
+import {readProjectIdFromProjectFile, isValidProjectFilePath} from '../utils/file'
 import {SystemEnvironment, ProjectInfo} from '../types'
 import { pullProjectInfo } from '../api/api'
 import open = require('open')
@@ -20,7 +20,7 @@ interface Props {
 export default async (props: Props, env: SystemEnvironment): Promise<void> => {
   const {resolver, out} = env
 
-  const {token} = readGraphcoolConfig(resolver)
+  const token = env.config.get('token')
   if (!token) {
     throw new Error(notAuthenticatedMessage)
   }

--- a/src/commands/quickstart.ts
+++ b/src/commands/quickstart.ts
@@ -9,7 +9,7 @@ interface Props {
 }
 
 export default async (props: Props, env: SystemEnvironment): Promise<void> => {
-  const alreadyAuthenticated = await props.checkAuth('quickstart')
+  const alreadyAuthenticated = await props.checkAuth(env, 'quickstart')
 
   if (alreadyAuthenticated) {
     open(`${docsEndpoint}/quickstart`)

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,4 @@
+import {Config} from './utils/config'
 import TestOut from './system/TestOut'
 export type Command =
   'auth'
@@ -19,8 +20,9 @@ export type Command =
 export type Region = 'eu-west-1'
 
 export interface GraphcoolConfig {
-  token: string
+  token?: string
 }
+export type GraphcoolConfigOptionName = 'token'
 
 export interface Resolver {
   read(path: string): string
@@ -84,11 +86,13 @@ export interface Out {
 export interface SystemEnvironment {
   out: Out
   resolver: Resolver
+  config: Config
 }
 
 export interface TestSystemEnvironment {
   out: TestOut
   resolver: Resolver
+  config: Config
 }
 
 export interface APIError {
@@ -98,4 +102,4 @@ export interface APIError {
 }
 
 export type AuthTrigger = 'auth' | 'init' | 'quickstart'
-export type CheckAuth = (authTrigger: AuthTrigger) => Promise<boolean>
+export type CheckAuth = (env: SystemEnvironment, authTrigger: AuthTrigger) => Promise<boolean>

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -1,0 +1,42 @@
+import {
+  Resolver,
+  GraphcoolConfig,
+  GraphcoolConfigOptionName
+} from '../types'
+
+import { graphcoolConfigFilePath } from './constants'
+
+export class Config {
+  configs: GraphcoolConfig
+  resolver: Resolver
+
+  constructor(resolver: Resolver) {
+    this.resolver = resolver
+    this.configs = {}
+  }
+
+  set(updates: GraphcoolConfig) {
+    this.configs = Object.assign(this.configs, updates)
+  }
+
+  unset(name: GraphcoolConfigOptionName) {
+    delete this.configs[name]
+  }
+
+  get(name: GraphcoolConfigOptionName): any {
+    return this.configs[name]
+  }
+
+  load() {
+    if (!this.resolver.exists(graphcoolConfigFilePath)) {
+      return
+    }
+
+    const configContent = this.resolver.read(graphcoolConfigFilePath)
+    this.configs = JSON.parse(configContent)
+  }
+
+  save() {
+    this.resolver.write(graphcoolConfigFilePath, JSON.stringify(this.configs, null, 2))
+  }
+}

--- a/src/utils/file.ts
+++ b/src/utils/file.ts
@@ -82,20 +82,3 @@ export function isValidSchemaFilePath(schemaFilePath?: string): boolean {
   }
   return schemaFilePath.endsWith(schemaFileSuffix)
 }
-
-/*
- * Graphcool Config (~/.graphcool)
- */
-
-export function readGraphcoolConfig(resolver: Resolver): GraphcoolConfig {
-  const configFileContent = resolver.read(graphcoolConfigFilePath)
-  return JSON.parse(configFileContent)
-}
-
-export function writeGraphcoolConfig(config: GraphcoolConfig, resolver: Resolver): void {
-  resolver.write(graphcoolConfigFilePath, JSON.stringify(config, null, 2))
-}
-
-export function deleteGraphcoolConfig(resolver: Resolver): void {
-  resolver.delete(graphcoolConfigFilePath)
-}

--- a/tests/auth.test.ts
+++ b/tests/auth.test.ts
@@ -1,5 +1,6 @@
 import test from 'ava'
 import TestResolver from '../src/system/TestResolver'
+import { Config } from '../src/utils/config'
 import authCommand from '../src/commands/auth'
 import { authEndpoint, graphcoolConfigFilePath, systemAPIEndpoint } from '../src/utils/constants'
 import TestAuthServer from '../src/api/TestAuthServer'
@@ -86,8 +87,12 @@ test('Succeeding auth with existing token', async t => {
 })
 
 function testEnvironment(storage: any): TestSystemEnvironment {
+  const resolver = new TestResolver(storage)
+  const config = new Config(resolver)
+
   return {
-    resolver: new TestResolver(storage),
+    resolver: resolver,
     out: new TestOut(),
+    config: config
   }
 }

--- a/tests/clone.test.ts
+++ b/tests/clone.test.ts
@@ -1,5 +1,6 @@
 import test from 'ava'
 import TestResolver from '../src/system/TestResolver'
+import { Config } from '../src/utils/config'
 import initCommand from '../src/commands/init'
 import {
   systemAPIEndpoint,
@@ -194,9 +195,12 @@ async function init(props, env) {
 }
 
 function testEnvironment(storage: any): TestSystemEnvironment {
+  const resolver = new TestResolver(storage)
+  const config = new Config(resolver)
+
   return {
-    resolver: new TestResolver(storage),
+    resolver: resolver,
     out: new TestOut(),
+    config: config
   }
 }
-

--- a/tests/export.test.ts
+++ b/tests/export.test.ts
@@ -1,5 +1,6 @@
 import test from 'ava'
 import TestResolver from '../src/system/TestResolver'
+import { Config } from '../src/utils/config'
 import exportCommand from '../src/commands/export'
 import { systemAPIEndpoint, graphcoolProjectFileName, graphcoolConfigFilePath } from '../src/utils/constants'
 import { TestSystemEnvironment } from '../src/types'
@@ -64,9 +65,12 @@ test('Export with multiple project files', async t => {
 })
 
 function testEnvironment(storage: any): TestSystemEnvironment {
+  const resolver = new TestResolver(storage)
+  const config = new Config(resolver)
+
   return {
-    resolver: new TestResolver(storage),
+    resolver: resolver,
     out: new TestOut(),
+    config: config
   }
 }
-

--- a/tests/init.test.ts
+++ b/tests/init.test.ts
@@ -1,5 +1,6 @@
 import test from 'ava'
 import TestResolver from '../src/system/TestResolver'
+import { Config } from '../src/utils/config'
 import initCommand from '../src/commands/init'
 import {
   systemAPIEndpoint,
@@ -171,9 +172,12 @@ test('Succeeding project creation with alias', async t => {
 })
 
 function testEnvironment(storage: any): TestSystemEnvironment {
+  const resolver = new TestResolver(storage)
+  const config = new Config(resolver)
+
   return {
-    resolver: new TestResolver(storage),
+    resolver: resolver,
     out: new TestOut(),
+    config: config
   }
 }
-

--- a/tests/mock_data/mockData.ts
+++ b/tests/mock_data/mockData.ts
@@ -5,6 +5,12 @@ import {modifiedTwitterSchema, simpleTwitterSchemaWithSystemFields, modifiedTwit
  */
 export const testToken = 'abcdefghijklmnopqrstuvwxyz'
 
+export const mockConfigFile = `\
+{
+  "token": "1234"
+}\
+`
+
 export const mockProjectFile1 = `\
 # project: abcdefghijklmn
 # version: 1

--- a/tests/pull.test.ts
+++ b/tests/pull.test.ts
@@ -1,5 +1,6 @@
 import test from 'ava'
 import TestResolver from '../src/system/TestResolver'
+import { Config } from '../src/utils/config'
 import pullCommand from '../src/commands/pull'
 import { systemAPIEndpoint, graphcoolProjectFileName, graphcoolConfigFilePath } from '../src/utils/constants'
 import {
@@ -239,8 +240,12 @@ async function pull(props, env) {
 }
 
 function testEnvironment(storage: any): TestSystemEnvironment {
+  const resolver = new TestResolver(storage)
+  const config = new Config(resolver)
+
   return {
-    resolver: new TestResolver(storage),
+    resolver: resolver,
     out: new TestOut(),
+    config: config
   }
 }

--- a/tests/push.test.ts
+++ b/tests/push.test.ts
@@ -1,5 +1,6 @@
 import test from 'ava'
 import TestResolver from '../src/system/TestResolver'
+import { Config } from '../src/utils/config'
 import 'isomorphic-fetch'
 import pushCommand from '../src/commands/push'
 import statusCommand from '../src/commands/status'
@@ -166,9 +167,13 @@ test('Status with potential data loss', async t => {
 })
 
 function testEnvironment(storage: any): TestSystemEnvironment {
+  const resolver = new TestResolver(storage)
+  const config = new Config(resolver)
+
   return {
-    resolver: new TestResolver(storage),
+    resolver: resolver,
     out: new TestOut(),
+    config: config
   }
 }
 

--- a/tests/utils_config.test.ts
+++ b/tests/utils_config.test.ts
@@ -1,0 +1,77 @@
+import test from 'ava'
+import TestResolver from '../src/system/TestResolver'
+import TestOut from '../src/system/TestOut'
+import { Config } from '../src/utils/config'
+import { graphcoolConfigFilePath } from '../src/utils/constants'
+const configFileContent = '{"token":"1234"}'
+
+/*
+ Tests:
+ - load noops when config file does not exist
+ - load obtains configs from file
+ - set overrides specified configs
+ - unset removes specified config
+ - get returns config value
+ - save persists configs to file
+ */
+
+test('load noops when config file does not exist', async t => {
+  const resolver = new TestResolver({})
+  var config = new Config(resolver)
+  t.notThrows(() => { config.load() })
+})
+
+test('load obtains configs from file', async t => {
+  const resolver = new TestResolver({})
+  resolver.write(graphcoolConfigFilePath, configFileContent)
+
+  var config = new Config(resolver)
+  config.load()
+
+  t.is(config.configs.token, '1234')
+})
+
+test('set overrides specified configs', async t => {
+  const resolver = new TestResolver({})
+
+  var config = new Config(resolver)
+  config.set({ token: '1234' })
+  t.is(config.configs.token, '1234')
+})
+
+test('unset removes specified config', async t => {
+  const resolver = new TestResolver({})
+  resolver.write(graphcoolConfigFilePath, configFileContent)
+
+  var config = new Config(resolver)
+  config.unset('token')
+  t.is(config.configs.token, undefined)
+})
+
+test('get returns config value', async t => {
+  const resolver = new TestResolver({})
+  resolver.write(graphcoolConfigFilePath, configFileContent)
+
+  var config = new Config(resolver)
+  config.load()
+
+  t.is(config.get('token'), '1234')
+})
+
+test('save persists configs to file', async t => {
+  const resolver = new TestResolver({})
+  resolver.write(graphcoolConfigFilePath, configFileContent)
+
+  var config = new Config(resolver)
+  config.load()
+
+  config.set({ token: '4567' })
+  config.save()
+
+  const expectedConfig = `\
+{
+  "token": "4567"
+}\
+`
+  t.is(resolver.read(graphcoolConfigFilePath), expectedConfig)
+})

--- a/tests/utils_file.test.ts
+++ b/tests/utils_file.test.ts
@@ -1,5 +1,6 @@
 import test from 'ava'
 import TestResolver from '../src/system/TestResolver'
+import { Config } from '../src/utils/config'
 import TestOut from '../src/system/TestOut'
 import { graphcoolProjectFileName } from '../src/utils/constants'
 import { TestSystemEnvironment } from '../src/types'
@@ -44,10 +45,13 @@ test('readProjectIdFromProjectFile with a file missing a project id', async t =>
   t.is(project_id, undefined)
 })
 
-
 function testEnvironment(storage: any): TestSystemEnvironment {
+  const resolver = new TestResolver(storage)
+  const config = new Config(resolver)
+
   return {
-    resolver: new TestResolver(storage),
+    resolver: resolver,
     out: new TestOut(),
+    config: config
   }
 }


### PR DESCRIPTION
As part of #79, I wanted a way to persist a timestamp in the `~/.graphcoolrc` config file so that we only check for updates every X hours.

The function we currently use to write to the config file (`writeGraphcoolConfig`) isn't aware of the existing config. Instead, it only writes the values passed to the function.

This isn't a problem for now since we only write one value to the file (`token`), but once we start using the `~/.graphcoolrc` for more values (i.e. `lastUpdateCheck`) we will want a way to append new values to the config without removing the values already present.

Rather than use `writeGraphcoolConfig` and `readGraphcoolConfig` this PR proposes a different approach. We can load the config once at startup and include `config` within the `SystemEnvironment` that is already passed to every command. We can then use `env.config.get('token')` and `env.config.set({ token })` to read/write to the config.

If you prefer to keep the functional approach, I can change this PR to simply tweak `writeGraphcoolConfig` to load the config file and merge the updates instead of blindly squashing existing config.

@nikolasburk @schickling would love to get your thoughts.