### PR TITLE
Add region to `projects` list command

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -67,6 +67,7 @@ mutation addProject($schema: String!, $name: String!, $alias: String, $region: R
       schema
       alias
       version
+      region
     }
   }
 }
@@ -91,8 +92,9 @@ mutation addProject($schema: String!, $name: String!, $alias: String, $region: R
   schema = json.data.addProject.project.schema
   const returnedAlias = json.data.addProject.project.alias
   name = json.data.addProject.project.name
+  const returnedRegion = json.data.addProject.project.region
 
-  const projectInfo = {projectId, version, alias: returnedAlias, schema, name}
+  const projectInfo = {projectId, version, alias: returnedAlias, schema, name, region: returnedRegion}
 
   return projectInfo
 }
@@ -215,7 +217,7 @@ export async function fetchProjects(resolver: Resolver): Promise<[ProjectInfo]> 
   const query = `\
 {
   viewer {
-	  user {
+    user {
       projects {
         edges {
           node {
@@ -224,6 +226,7 @@ export async function fetchProjects(resolver: Resolver): Promise<[ProjectInfo]> 
             schema
             alias
             version
+            region
           }
         }
       }
@@ -240,6 +243,7 @@ export async function fetchProjects(resolver: Resolver): Promise<[ProjectInfo]> 
     alias: p.alias,
     schema: p.schema,
     version: p.version,
+    region: p.region,
   }))
 
   return projectInfos
@@ -256,6 +260,7 @@ query ($projectId: ID!){
       alias
       schema
       version
+      region
     }
   }
 }`
@@ -274,6 +279,7 @@ query ($projectId: ID!){
     schema: json.data.viewer.project.schema,
     alias: json.data.viewer.project.alias,
     version: String(json.data.viewer.project.version),
+    region: json.data.viewer.project.region,
   }
   return projectInfo
 }
@@ -352,6 +358,7 @@ mutation ($projectId: String!, $name: String!, $includeMutationCallbacks: Boolea
       alias
       schema
       version
+      region
     }
   }
 }`
@@ -369,6 +376,7 @@ mutation ($projectId: String!, $name: String!, $includeMutationCallbacks: Boolea
     schema: json.data.cloneProject.project.schema,
     alias: json.data.cloneProject.project.alias,
     version: String(json.data.cloneProject.project.version),
+    region: json.data.cloneProject.project.region,
   }
 
   return projectInfo

--- a/src/commands/projects.ts
+++ b/src/commands/projects.ts
@@ -24,14 +24,14 @@ export default async (props: Props, env: SystemEnvironment): Promise<void> => {
 
     const data = projects.map(project => {
       const isCurrentProject = currentProjectId !== null && (currentProjectId === project.projectId || currentProjectId === project.alias)
-      return [isCurrentProject ? '*' : ' ', `${project.alias || project.projectId}   `, project.name]
+      return [isCurrentProject ? '*' : ' ', `${project.alias || project.projectId}   `, project.name, project.region]
     })
 
     const output = table(data, {
       border: getBorderCharacters('void'),
       columnDefault: {
         paddingLeft: '0',
-        paddingRight: '1',
+        paddingRight: '2',
       },
       drawHorizontalLine: () => false,
     }).trimRight()

--- a/src/commands/projects.ts
+++ b/src/commands/projects.ts
@@ -3,6 +3,7 @@ import { fetchProjects } from '../api/api'
 import figures = require('figures')
 import {couldNotFetchProjectsMessage, graphcoolProjectFileName} from '../utils/constants'
 import { readProjectIdFromProjectFile } from '../utils/file'
+import { regionEnumToOption } from '../utils/utils'
 
 const {table, getBorderCharacters} = require('table')
 const debug = require('debug')('graphcool')
@@ -24,7 +25,7 @@ export default async (props: Props, env: SystemEnvironment): Promise<void> => {
 
     const data = projects.map(project => {
       const isCurrentProject = currentProjectId !== null && (currentProjectId === project.projectId || currentProjectId === project.alias)
-      return [isCurrentProject ? '*' : ' ', `${project.alias || project.projectId}   `, project.name, project.region]
+      return [isCurrentProject ? '*' : ' ', `${project.alias || project.projectId}   `, project.name, regionEnumToOption(project.region)]
     })
 
     const output = table(data, {

--- a/src/types.ts
+++ b/src/types.ts
@@ -49,6 +49,7 @@ export interface ProjectInfo {
   schema: string
   version: string
   alias: string
+  region: string
 }
 
 export interface MigrationMessage {

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -22,3 +22,7 @@ export function makePartsEnclodesByCharacterBold(str: string, character: string)
   }
   return components.join(chalk.bold(`\``))
 }
+
+export function regionEnumToOption(regionEnum: string): string {
+  return regionEnum.toLowerCase().replace(/_/g, '-')
+}

--- a/tests/fixtures/mock_data.ts
+++ b/tests/fixtures/mock_data.ts
@@ -238,7 +238,8 @@ export const mockedPullProjectResponse1 = `\
         "alias": null,
         "version": 1,
         "id": "cj26898xqm9tz0126n34d64ey",
-        "schema": "${mockedPullResponseSchema}"
+        "schema": "${mockedPullResponseSchema}",
+        "region": "EU_WEST_1"
       }
     }
   }
@@ -253,7 +254,8 @@ export const mockedPullProjectResponseWithAlias1 = `\
         "alias": "example",
         "version": 1,
         "id": "cj26898xqm9tz0126n34d64ey",
-        "schema": "${mockedPullResponseSchema}"
+        "schema": "${mockedPullResponseSchema}",
+        "region": "EU_WEST_1"
       }
     }
   }
@@ -268,7 +270,8 @@ export const mockedPullProjectResponse2 = `\
         "alias": null,
         "version": 2,
         "id": "cj26898xqm9tz0126n34d64ey",
-        "schema": "${mockedPullResponseSchema}"
+        "schema": "${mockedPullResponseSchema}",
+        "region": "EU_WEST_1"
       }
     }
   }
@@ -283,7 +286,8 @@ export const mockedPullProjectResponseWithAlias2 = `\
         "alias": "example",
         "version": 2,
         "id": "cj26898xqm9tz0126n34d64ey",
-        "schema": "${mockedPullResponseSchema}"
+        "schema": "${mockedPullResponseSchema}",
+        "region": "EU_WEST_1"
       }
     }
   }
@@ -325,7 +329,8 @@ export const mockedCreateProjectResponse = `\
         "schema": "type Tweet {\\n  id: ID!\\n  createdAt: DateTime!\\n  updatedAt: DateTime!\\n  text: String!\\n}\\n",
         "version": 1,
         "alias": null,
-        "name": "Example"
+        "name": "Example",
+        "region": "EU_WEST_1"
       }
     }
   }
@@ -340,7 +345,8 @@ export const mockedClonedProjectResponse = `\
         "schema": "type Tweet {\\n  id: ID!\\n  createdAt: DateTime!\\n  updatedAt: DateTime!\\n  text: String!\\n}\\n",
         "version": 1,
         "alias": null,
-        "name": "Clone of Example"
+        "name": "Clone of Example",
+        "region": "EU_WEST_1"
       }
     }
   }
@@ -355,7 +361,8 @@ export const mockedCreateProjectResponseWithAlias = `\
         "schema": "type Tweet {\\n  id: ID!\\n  createdAt: DateTime!\\n  updatedAt: DateTime!\\n  text: String!\\n}\\n",
         "alias": "example",
         "version": 1,
-        "name": "Example"      
+        "name": "Example",
+        "region": "EU_WEST_1"
       }
     }
   }


### PR DESCRIPTION
Fixes #106 

A bunch of GraphQL queries are now "unnecessarily" requesting `region`, but I prefer this than to make `ProjectInfo.region` null-able.

We may want to add tests for the `projects` command in a following PR.

Sample output:

```
$ gc projects
   ciz4pp0zj07xa0157aim80000     Example Project  eu-west-1
*  cj3wapx0ksui90103lzds0000     Bookmark         eu-west-1
```

I increased the `paddingRight` from `1` to `2` as the project name and region were a bit tight. 

Let me know if there's anything else you had in mind for this issue.

@schickling @nikolasburk 