### PR TITLE
Fix issue with interactive init ignoring --region option

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -91,7 +91,7 @@ async function main() {
       const outputPath = argv['output'] || argv['o']
 
       if (!schemaUrl && !copyProjectId) {
-        const props = {name, alias, outputPath, checkAuth}
+        const props = {name, alias, outputPath, checkAuth, region}
         await interactiveInitCommand(props, env)
       } else {
         await checkAuth(env, 'init')


### PR DESCRIPTION
When sent into the interactive init flow the `--region` option was omitted resulting in the default region being picked.

**Before:**

```
$ DEBUG=graphcool gc init --region US_WEST_2
⠹ Creating project Pollenkicker Puppy...  graphcool Send request to https://api.graph.cool/system
  graphcool Payload:
  graphcool {"query":"mutation addProject($schema: String!, $name: String!, $alias: String, $region: Region) {\n  addProject(input: {\n    name: $name,\n    schema: $schema,\n    alias: $alias,\n    region: $region,\n    clientMutationId: \"static\"\n  }) {\n    project {\n      id\n      name\n      schema\n      alias\n      version\n    }\n  }\n}\n","variables":{"name":"Pollenkicker Puppy","schema":"type User {\n  id: ID!\n}\n\n# type Tweet {\n#   text: String!\n# }\n"}} +0ms
```

```json
{
  "variables": {
    "name": "Pollenkicker Puppy",
    "schema": "type User {\n  id: ID!\n}\n\n# type Tweet {\n#   text: String!\n# }\n"
  }
}
```

Notice omitted `region` in `variables`

**After:**

```
$ DEBUG=graphcool gc init --region US_WEST_2
⠹ Creating project Stonebow Slave...  graphcool Send request to https://api.graph.cool/system
  graphcool Payload:
  graphcool {"query":"mutation addProject($schema: String!, $name: String!, $alias: String, $region: Region) {\n  addProject(input: {\n    name: $name,\n    schema: $schema,\n    alias: $alias,\n    region: $region,\n    clientMutationId: \"static\"\n  }) {\n    project {\n      id\n      name\n      schema\n      alias\n      version\n    }\n  }\n}\n","variables":{"name":"Stonebow Slave","schema":"type User {\n  id: ID!\n}\n\n# type Tweet {\n#   text: String!\n# }\n","region":"US_WEST_2"}} +0ms
```

```json
{
  "variables": {
    "name": "Stonebow Slave",
    "schema": "type User {\n  id: ID!\n}\n\n# type Tweet {\n#   text: String!\n# }\n",
    "region": "US_WEST_2"
  }
}
```

**And a sanity check that it works:**

```
$ gc projects
   cj47to7kdwfcb0121jkzl0000     Stonebow Slave           US_WEST_2
   cj47toudewggi0121byy30000     Pollenkicker Puppy       EU_WEST_1
```

This is a quick fix to resolve the issue.

As a larger PR we may want to refactor the command tests in order for them to go through the `index.js` codepath or dumb down `index.js`. At the moment the tests call the command functions directly, i.e. `initCommand(...)` which completely by passes any bugs in `index.js`.

@schickling @nikolasburk 