### PR TITLE
update path for facebook-authentication module

### DIFF
--- a/packages/graphcool-cli-core/src/commands/init/index.ts
+++ b/packages/graphcool-cli-core/src/commands/init/index.ts
@@ -146,7 +146,7 @@ export default class Init extends Command {
    2) Install a graphcool module to your project:
    
       ${chalk.bold('facebook-authentication')}
-      $ ${chalk.cyan('graphcool module add graphcool/modules/authentication/facebook-authentication')}
+      $ ${chalk.cyan('graphcool module add graphcool/modules/authentication/facebook')}
       
       ${chalk.bold('algolia-syncing')}
       $ ${chalk.cyan('graphcool module add graphcool/modules/syncing/algolia')}


### PR DESCRIPTION
I suggest the path `authentication/facebook` instead, as it's more concise.